### PR TITLE
Dev

### DIFF
--- a/facility/docs/dependencies.puml
+++ b/facility/docs/dependencies.puml
@@ -1,0 +1,16 @@
+@startuml
+skinparam actorStyle hollow
+
+title Dependencies
+(view) --> (Mod)
+(view) --> (domain)
+(view) --> (entities)
+(view) --> (modelv)
+(actions) --> (entities)
+(actions) --> (events)
+(actions) --> (Mod)
+(entities) --> (events)
+(entities) --> (Mod)
+(events) --> (Mod)
+(Mod) --> (domain)
+@enduml

--- a/facility/kdeploy.sh
+++ b/facility/kdeploy.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+kalix service deploy facility registry.hub.docker.com/max8github/facility:"$1" --secret-env INSTALL_TOKEN=tw-creds/INSTALL_TOKEN

--- a/facility/postman/Kalix.facility.postman_collection.json
+++ b/facility/postman/Kalix.facility.postman_collection.json
@@ -9,6 +9,319 @@
 	},
 	"item": [
 		{
+			"name": "Create TCL Facility",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"var facility_id = \"4463962\";",
+							"postman.setEnvironmentVariable(\"facility_id\", facility_id);",
+							"",
+							"",
+							"var facilityName = \"Tennisclub Ladenburg\";",
+							"var resourceName = \"court1\";",
+							"",
+							"var street = \"Römerstadion 6\";",
+							"var city = \"Ladenburg\";",
+							"",
+							"console.info(\"Entity id is: \"+ facility_id);",
+							"console.info(\"Facilityname is: \"+ facilityName);",
+							"console.info(\"Street is: \"+ street);",
+							"console.info(\"City is: \"+ city);",
+							"console.info(\"Resource is: \"+ resourceName);",
+							"",
+							"pm.variables.set(\"facilityName\", facilityName);",
+							"pm.variables.set(\"street\", street);",
+							"pm.variables.set(\"city\", city);",
+							"pm.variables.set(\"resourceName\", resourceName);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"//pm.environment.set(\"facility_id\", pm.response.text());"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"name\": \"{{facilityName}}\",\n    \"address\": {\n      \"street\": \"{{street}}\",\n      \"city\": \"{{city}}\"\n    }\n  }"
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/facility/{{facility_id}}/create",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"facility",
+						"{{facility_id}}",
+						"create"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "register court 1",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"var resourceId = \"3d228lvsdmdjmj79662t8r1fh4\";//pm.variables.replaceIn('{{$randomLoremWord}}');",
+							"var resourceName = \"court 1\";//pm.variables.replaceIn('{{$randomLoremWord}}');",
+							"var timeSlotsSize = 24;",
+							"",
+							"console.info(\"Resource is: \"+ resourceId);",
+							"console.info(\"Resource is: \"+ resourceName);",
+							"console.info(\"Resource size is: \"+ timeSlotsSize);",
+							"",
+							"pm.variables.set(\"resourceId\", resourceId);",
+							"pm.variables.set(\"resourceName\", resourceName);",
+							"pm.variables.set(\"timeSlotsSize\", timeSlotsSize);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.environment.set(\"resource_id\", pm.response.text().replace(/\"/g, \"\"));"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"resourceId\": \"{{resourceId}}\",\n    \"resourceName\": \"{{resourceName}}\",\n    \"size\": {{timeSlotsSize}}\n}\n"
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/facility/{{facility_id}}/resource/submit",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"facility",
+						"{{facility_id}}",
+						"resource",
+						"submit"
+					]
+				},
+				"description": "Creates a new Resource entity and adds its entity id into Facility"
+			},
+			"response": []
+		},
+		{
+			"name": "register court 2",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"var resourceId = \"63hd39cd9ppt8tajp76vglt394\";//pm.variables.replaceIn('{{$randomLoremWord}}');",
+							"var resourceName = \"court 2\";//pm.variables.replaceIn('{{$randomLoremWord}}');",
+							"var timeSlotsSize = 24;",
+							"",
+							"console.info(\"Resource is: \"+ resourceId);",
+							"console.info(\"Resource is: \"+ resourceName);",
+							"console.info(\"Resource size is: \"+ timeSlotsSize);",
+							"",
+							"pm.variables.set(\"resourceId\", resourceId);",
+							"pm.variables.set(\"resourceName\", resourceName);",
+							"pm.variables.set(\"timeSlotsSize\", timeSlotsSize);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.environment.set(\"resource_id\", pm.response.text().replace(/\"/g, \"\"));"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"resourceId\": \"{{resourceId}}\",\n    \"resourceName\": \"{{resourceName}}\",\n    \"size\": {{timeSlotsSize}}\n}\n"
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/facility/{{facility_id}}/resource/submit",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"facility",
+						"{{facility_id}}",
+						"resource",
+						"submit"
+					]
+				},
+				"description": "Creates a new Resource entity and adds its entity id into Facility"
+			},
+			"response": []
+		},
+		{
+			"name": "my twist command",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"actions\": [],\n  \"attachments\": [],\n  \"channel_id\": \"473452\",\n  \"content\": \"2023-07-02, 14, Bernhard\",\n  \"creator\": 717450,\n  \"creator_name\": \"Max\",\n  \"deleted\": false,\n  \"deleted_by\": null,\n  \"direct_group_mentions\": [],\n  \"direct_mentions\": [],\n  \"groups\": [\n    2\n  ],\n  \"id\": 84184313,\n  \"last_edited_ts\": null,\n  \"obj_index\": 2,\n  \"posted\": \"2023-06-28 13:25:53\",\n  \"reactions\": {},\n  \"recipients\": [],\n  \"system_message\": null,\n  \"thread_id\": 4463962,\n  \"to_emails\": [],\n  \"url\": \"https://twist.com/a/176177/ch/473452/t/4463962/c/84184313\",\n  \"version\": 0,\n  \"workspace_id\": 176177\n}\n",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/outwebhook",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"outwebhook"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create 16:00 Reservation",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"// var username = pm.variables.replaceIn('{{$randomEmail}}');",
+							"var username = 'max.calderoni@gmail.com';",
+							"var timeSlot = 22;",
+							"var date = \"2023-07-01\";",
+							"",
+							"console.info(\"username is: \"+ username);",
+							"console.info(\"timeSlot is: \"+ timeSlot);",
+							"console.info(\"date is: \"+ date);",
+							"",
+							"pm.variables.set(\"username\", username);",
+							"pm.variables.set(\"timeSlot\", timeSlot);",
+							"pm.variables.set(\"date\", date);"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.environment.set(\"reservation_id\", pm.response.text().replace(/\"/g, \"\"));"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n      \"emails\": [\"{{username}}\"],\n      \"timeSlot\": \"{{timeSlot}}\",\n      \"date\": \"{{date}}\"\n}"
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/facility/{{facility_id}}/reservation/create",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"facility",
+						"{{facility_id}}",
+						"reservation",
+						"create"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Create Facility",
 			"event": [
 				{
@@ -96,7 +409,7 @@
 					"listen": "prerequest",
 					"script": {
 						"exec": [
-							"var facility_id = \"4463962\";",
+							"var facility_id = \"5912f3c4\";",
 							"postman.setEnvironmentVariable(\"facility_id\", facility_id);",
 							"",
 							"",
@@ -275,12 +588,15 @@
 					"listen": "prerequest",
 					"script": {
 						"exec": [
+							"var resourceId = pm.variables.replaceIn('{{$randomLoremWord}}');",
 							"var resourceName = pm.variables.replaceIn('{{$randomLoremWord}}');",
 							"var timeSlotsSize = 24;",
 							"",
+							"console.info(\"Resource is: \"+ resourceId);",
 							"console.info(\"Resource is: \"+ resourceName);",
 							"console.info(\"Resource size is: \"+ timeSlotsSize);",
 							"",
+							"pm.variables.set(\"resourceId\", resourceId);",
 							"pm.variables.set(\"resourceName\", resourceName);",
 							"pm.variables.set(\"timeSlotsSize\", timeSlotsSize);"
 						],
@@ -308,7 +624,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"resourceName\": \"{{resourceName}}\",\n    \"size\": {{timeSlotsSize}}\n}\n"
+					"raw": "{\n    \"resourceId\": \"{{resourceId}}\",\n    \"resourceName\": \"{{resourceName}}\",\n    \"size\": {{timeSlotsSize}}\n}\n"
 				},
 				"url": {
 					"raw": "{{protocol}}://{{host}}:{{port}}/facility/{{facility_id}}/resource/submit",
@@ -486,7 +802,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "{{protocol}}://{{host}}:{{port}}/facility/by_name/STB",
+					"raw": "{{protocol}}://{{host}}:{{port}}/facility/by_name/Tennisclub%20Ladenburg",
 					"protocol": "{{protocol}}",
 					"host": [
 						"{{host}}"
@@ -495,7 +811,60 @@
 					"path": [
 						"facility",
 						"by_name",
-						"STB"
+						"Tennisclub%20Ladenburg"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "View Full STB Facility",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{protocol}}://{{host}}:{{port}}/joined_facility_resources/4463962",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"joined_facility_resources",
+						"4463962"
 					]
 				}
 			},
@@ -564,9 +933,9 @@
 						"exec": [
 							"// var username = pm.variables.replaceIn('{{$randomEmail}}');",
 							"var username = 'max.calderoni@gmail.com';",
-							"var timeSlot = pm.variables.replaceIn('{{$randomInt}}');",
+							"var timeSlot = 18;//pm.variables.replaceIn('{{$randomInt}}');",
 							"var randDate = pm.variables.replaceIn('{{$randomDateFuture}}');",
-							"var date = new Date(randDate).toISOString().substr(0, 10);",
+							"var date = \"2023-06-22\";//new Date(randDate).toISOString().substr(0, 10);",
 							"",
 							"if(timeSlot > 100) {",
 							"    timeSlot = Math.ceil(timeSlot/100);",
@@ -606,7 +975,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n      \"username\": \"{{username}}\",\n      \"timeSlot\": \"{{timeSlot}}\",\n      \"date\": \"{{date}}\"\n}"
+					"raw": "{\n      \"emails\": [\"{{username}}\"],\n      \"timeSlot\": \"{{timeSlot}}\",\n      \"date\": \"{{date}}\"\n}"
 				},
 				"url": {
 					"raw": "{{protocol}}://{{host}}:{{port}}/facility/{{facility_id}}/reservation/create",
@@ -795,7 +1164,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"actions\": [],\n  \"attachments\": [],\n  \"channel_id\": \"473452\",\n  \"content\": \"2023-06-22, 16, Max\",\n  \"creator\": 717450,\n  \"creator_name\": \"Giuliano\",\n  \"deleted\": false,\n  \"deleted_by\": null,\n  \"direct_group_mentions\": [],\n  \"direct_mentions\": [],\n  \"groups\": [\n    2\n  ],\n  \"id\": 84184313,\n  \"last_edited_ts\": null,\n  \"obj_index\": 2,\n  \"posted\": \"2023-06-12 20:17:53\",\n  \"reactions\": {},\n  \"recipients\": [],\n  \"system_message\": null,\n  \"thread_id\": 4463962,\n  \"to_emails\": [],\n  \"url\": \"https://twist.com/a/176177/ch/473452/t/4463962/c/84184313\",\n  \"version\": 0,\n  \"workspace_id\": 176177\n}\n",
+					"raw": "{\n  \"actions\": [],\n  \"attachments\": [],\n  \"channel_id\": \"473452\",\n  \"content\": \"2023-06-27, 19, Max\",\n  \"creator\": 717450,\n  \"creator_name\": \"Giuliano short hair\",\n  \"deleted\": false,\n  \"deleted_by\": null,\n  \"direct_group_mentions\": [],\n  \"direct_mentions\": [],\n  \"groups\": [\n    2\n  ],\n  \"id\": 84184313,\n  \"last_edited_ts\": null,\n  \"obj_index\": 2,\n  \"posted\": \"2023-06-24 12:04:53\",\n  \"reactions\": {},\n  \"recipients\": [],\n  \"system_message\": null,\n  \"thread_id\": 4463962,\n  \"to_emails\": [],\n  \"url\": \"https://twist.com/a/176177/ch/473452/t/4463962/c/84184313\",\n  \"version\": 0,\n  \"workspace_id\": 176177\n}\n",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -817,7 +1186,7 @@
 			"response": []
 		},
 		{
-			"name": "twist incoming webhook doco (CONFIRMATION)",
+			"name": "twist incoming webhook (CONFIRMATION)",
 			"event": [
 				{
 					"listen": "prerequest",
@@ -849,7 +1218,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"content\":  \"Reservation confirmed. Time: 3, Attendees: max.calderoni@gmail.com\",\n  \"actions\": [\n    {\n      \"action\": \"open_url\",\n      \"url\": \"21850ec14e20443f87a707bf808c8a82\",\n      \"type\": \"action\",\n      \"button_text\": \"Go to Calendar\"\n    }\n  ]\n}",
+					"raw": "{\n  \"content\":  \"Reservation confirmed. Time: 3, Attendees: max.calderoni@gmail.com\",\n  \"actions\": [\n    {\n      \"action\": \"open_url\",\n      \"url\": \"https://www.example.com\",\n      \"type\": \"action\",\n      \"button_text\": \"Go to Calendar\"\n    }\n  ]\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -933,7 +1302,7 @@
 						},
 						{
 							"key": "target_url",
-							"value": "https://muddy-frog-9741.us-east1.kalix.app:443/outwebhook",
+							"value": "https://{{host}}:443/outwebhook",
 							"type": "text"
 						}
 					]

--- a/facility/src/main/java/com/rez/facility/api/CalendarFactory.java
+++ b/facility/src/main/java/com/rez/facility/api/CalendarFactory.java
@@ -39,7 +39,7 @@ public class CalendarFactory {
      * If modifying these scopes, delete your previously saved tokens/ folder.
      */
     private static final List<String> SCOPES = Collections.singletonList(CalendarScopes.CALENDAR);
-    private static final String CREDENTIALS_FILE_PATH = "/credentials.json";
+    private static final String CREDENTIALS_FILE_PATH = "credentials.json";
     private static final String APPLICATION_NAME = "Google Calendar API Java Quickstart";
 
 
@@ -58,7 +58,7 @@ public class CalendarFactory {
         }
         //Build service account credential
         HttpRequestInitializer requestInitializer;
-        try (InputStream in = DelegatingServiceAction.class.getResourceAsStream(CREDENTIALS_FILE_PATH)) {
+        try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(CREDENTIALS_FILE_PATH)) {
             if (in == null) {
                 throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
             }
@@ -85,8 +85,8 @@ public class CalendarFactory {
             throw new RuntimeException(e);
         }
         // Load client secrets.
-        Credential credentials = null;
-        try (InputStream in = DelegatingServiceAction.class.getResourceAsStream(CREDENTIALS_FILE_PATH)) {
+        Credential credentials;
+        try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(CREDENTIALS_FILE_PATH)) {
             if (in == null) {
                 throw new FileNotFoundException("Resource not found: " + CREDENTIALS_FILE_PATH);
             }
@@ -104,9 +104,8 @@ public class CalendarFactory {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        Calendar service = new Calendar.Builder(httpTransport, JSON_FACTORY, credentials)
+        return new Calendar.Builder(httpTransport, JSON_FACTORY, credentials)
                 .setApplicationName(APPLICATION_NAME)
                 .build();
-        return service;
     }
 }

--- a/facility/src/main/java/com/rez/facility/api/FacilityEntity.java
+++ b/facility/src/main/java/com/rez/facility/api/FacilityEntity.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.UUID;
 
 @EntityKey("facilityId")
@@ -29,7 +28,7 @@ public class FacilityEntity extends EventSourcedEntity<Facility, FacilityEvent> 
 
     @Override
     public Facility emptyState() {
-        return new Facility(entityId, "noname", new Address("nostreet", "nocity"), Collections.emptySet());
+        return Facility.create(entityId).withName("noname").withAddress(new Address("nostreet", "nocity"));
     }
 
     @Acl(allow = @Acl.Matcher(principal = Acl.Principal.ALL))

--- a/facility/src/main/java/com/rez/facility/api/Mod.java
+++ b/facility/src/main/java/com/rez/facility/api/Mod.java
@@ -14,7 +14,10 @@ public final class Mod {
     public record Facility(String name, Address address, Set<String> resourceIds) {
 
         public com.rez.facility.domain.Facility toFacilityState(String entityId) {
-            return new com.rez.facility.domain.Facility(entityId, name, address.toAddressState(), resourceIds);
+            return com.rez.facility.domain.Facility.create(entityId)
+                    .withName(name)
+                    .withAddress(address.toAddressState())
+                    .withResourceIds(resourceIds);
         }
 
         public static Facility fromFacilityState(com.rez.facility.domain.Facility facilityState) {
@@ -40,6 +43,8 @@ public final class Mod {
         }
     }
 
+    //todo: there should be just LocalDateTime here, timeSlot, *and* the location, as it will be useful when creating the cal event
+    //todo: maybe this is my value object to pass around throughout, in which case, i must also add: fac id, res id, rez id
     public record Reservation(List<String> emails, int timeSlot, LocalDate date) {
         public static Reservation fromReservationState(ReservationState reservationState) {
             return new Reservation(reservationState.emails(), reservationState.timeSlot(), reservationState.date());

--- a/facility/src/main/java/com/rez/facility/domain/Facility.java
+++ b/facility/src/main/java/com/rez/facility/domain/Facility.java
@@ -5,6 +5,15 @@ import java.util.Set;
 
 public record Facility(String facilityId, String name, Address address, Set<String> resourceIds) {
 
+    public static Facility create(String facilityId) {
+        return new Facility(facilityId, "", new Address("", ""), new HashSet<>());
+    }
+
+    public Facility withFacilityId(String facilityId) {
+        Set<String> ids = (resourceIds == null) ? new HashSet<>() : new HashSet<>(resourceIds);
+        return new Facility(facilityId, name, address, ids);
+    }
+
     public Facility withResourceId(String resourceId) {
         Set<String> ids = (resourceIds == null) ? new HashSet<>() : new HashSet<>(resourceIds);
         ids.add(resourceId);
@@ -17,11 +26,23 @@ public record Facility(String facilityId, String name, Address address, Set<Stri
         return new Facility(facilityId, name, address, ids);
     }
 
+    public Facility withResourceIds(Set<String> resourceIds) {
+        Set<String> ids = new HashSet<>();
+        if(resourceIds != null)
+            ids = new HashSet<>(resourceIds);
+        if(this.resourceIds != null) {
+            ids.addAll(this.resourceIds);
+        }
+        return new Facility(facilityId, name, address, ids);
+    }
+
     public Facility withName(String newName) {
-        return new Facility(facilityId, newName, address, resourceIds);
+        Set<String> ids = resourceIds == null ? new HashSet<>() : resourceIds;
+        return new Facility(facilityId, newName, address, ids);
     }
 
     public Facility withAddress(Address newAddress) {
-        return new Facility(facilityId, name, newAddress, resourceIds);
+        Set<String> ids = resourceIds == null ? new HashSet<>() : resourceIds;
+        return new Facility(facilityId, name, newAddress, ids);
     }
 }

--- a/facility/src/main/java/com/rez/facility/parsers/StringParser.java
+++ b/facility/src/main/java/com/rez/facility/parsers/StringParser.java
@@ -1,0 +1,35 @@
+package com.rez.facility.parsers;
+
+import com.rez.facility.spi.Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+public class StringParser implements Parser {
+    private static final Logger log = LoggerFactory.getLogger(StringParser.class);
+
+    @Override
+    public Result parse(String content) {
+        try {
+            String[] parts = content.split(",");
+            LocalDate date = LocalDate.parse(parts[0].trim());
+            int hourOfDay = Integer.parseInt(parts[1].trim());
+            hourOfDay = (hourOfDay > 23 || hourOfDay < 0) ? 23 : hourOfDay;
+            String dateTime = date.atTime(java.time.LocalTime.of(hourOfDay, 0)).toString();
+
+            String attendee = parts[2].trim();
+            Set<String> attendees = new HashSet<>();
+            attendees.add(attendee);
+            return new Result(attendees, dateTime, "btoken", "book");//todo: btoken is hardcoded, and so is action
+        } catch (Exception e) {
+            log.error("COULD NOT PARSE MESSAGE INTO RESERVATION DETAILS. MESSAGE: '" + content + "', exception:\n" + e);
+//            return new Result(Set.of(""), LocalDateTime.now().toString(), "btoken", "book");
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/facility/src/main/java/com/rez/facility/view/JoinedFacilityResourcesView.java
+++ b/facility/src/main/java/com/rez/facility/view/JoinedFacilityResourcesView.java
@@ -1,88 +1,87 @@
-package com.rez.facility.view;
-
-import com.rez.facility.api.FacilityEntity;
-import com.rez.facility.api.FacilityEvent;
-import com.rez.facility.api.ResourceEntity;
-import com.rez.facility.api.ResourceEvent;
-import kalix.javasdk.annotations.Query;
-import kalix.javasdk.annotations.Subscribe;
-import kalix.javasdk.annotations.Table;
-import kalix.javasdk.annotations.ViewId;
-import kalix.javasdk.view.View;
-import org.springframework.web.bind.annotation.GetMapping;
-import reactor.core.publisher.Flux;
-
-/**
- * Note: for this JOIN to work, it must be enabled in docker-compose.yml.
- */
-@ViewId("joined-facility-resources")
-public class JoinedFacilityResourcesView {
-
-    @GetMapping("/joined_facility_resources/{facilityId}")
-    @Query(
-            """
-            SELECT *
-            FROM facilities
-            JOIN resources ON facilities.facilityId = resources.facilityId
-            WHERE facilities.facilityId = :facilityId
-            ORDER BY resources.resourceName
-            """)
-    public Flux<FacilityResource> get(String facilityId) {
-        return null;
-    }
-
-    @Table("facilities")
-    @Subscribe.EventSourcedEntity(FacilityEntity.class)
-    public static class Facilities extends View<FacilityV> {
-        public UpdateEffect<FacilityV> onEvent(FacilityEvent.Created created) {
-            String id = updateContext().eventSubject().orElse("");
-            return effects()
-                    .updateState(new FacilityV(created.facility().name(), created.facility().address().toAddressState(), id
-                    ));
-        }
-
-        public UpdateEffect<FacilityV> onEvent(FacilityEvent.Renamed event) {
-            return effects().updateState(viewState().withName(event.newName()));
-        }
-
-        public UpdateEffect<FacilityV> onEvent(FacilityEvent.AddressChanged event) {
-            return effects().updateState(viewState().withAddress(event.address().toAddressState()));
-        }
-
-        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ResourceSubmitted event) {
-            return effects().ignore();
-        }
-
-        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ResourceIdAdded event) {
-            return effects().updateState(viewState());
-        }
-
-        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ResourceIdRemoved event) {
-            return effects().updateState(viewState());
-        }
-
-        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ReservationCreated event) {
-            return effects().ignore();
-        }
-    }
-
-    @Table("resources")
-    @Subscribe.EventSourcedEntity(ResourceEntity.class)
-    public static class Resources extends View<ResourceV> {
-
-        public UpdateEffect<ResourceV> onEvent(ResourceEvent.ResourceCreated created) {
-            String id = updateContext().eventSubject().orElse("");
-            assert id.equals(created.entityId());
-            return effects().updateState(ResourceV.initialize(created.facilityId(),
-                    created.entityId(), created.resource().toResourceState()));
-        }
-
-        public UpdateEffect<ResourceV> onEvent(ResourceEvent.BookingAccepted event) {
-            return effects().ignore();
-        }
-
-        public UpdateEffect<ResourceV> onEvent(ResourceEvent.BookingRejected notInteresting) {
-            return effects().ignore();
-        }
-    }
-}
+//package com.rez.facility.view;
+//
+//import com.rez.facility.api.FacilityEntity;
+//import com.rez.facility.api.FacilityEvent;
+//import com.rez.facility.api.ResourceEntity;
+//import com.rez.facility.api.ResourceEvent;
+//import kalix.javasdk.annotations.Query;
+//import kalix.javasdk.annotations.Subscribe;
+//import kalix.javasdk.annotations.Table;
+//import kalix.javasdk.annotations.ViewId;
+//import kalix.javasdk.view.View;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import reactor.core.publisher.Flux;
+//
+///**
+// * Note: for this JOIN to work, it must be enabled in docker-compose.yml.
+// */
+//@ViewId("joined-facility-resources")
+//public class JoinedFacilityResourcesView {
+//
+//    @GetMapping("/joined_facility_resources/{facilityId}")
+//    @Query(
+//            """
+//            SELECT *
+//            FROM facilities
+//            JOIN resources ON facilities.facilityId = resources.facilityId
+//            WHERE facilities.facilityId = :facilityId
+//            ORDER BY resources.resourceName
+//            """)
+//    public Flux<FacilityResource> get(String facilityId) {
+//        return null;
+//    }
+//
+//    @Table("facilities")
+//    @Subscribe.EventSourcedEntity(FacilityEntity.class)
+//    public static class Facilities extends View<FacilityV> {
+//        public UpdateEffect<FacilityV> onEvent(FacilityEvent.Created created) {
+//            String id = updateContext().eventSubject().orElse("");
+//            return effects()
+//                    .updateState(new FacilityV(created.facility().name(), created.facility().address().toAddressState(), id
+//                    ));
+//        }
+//
+//        public UpdateEffect<FacilityV> onEvent(FacilityEvent.Renamed event) {
+//            return effects().updateState(viewState().withName(event.newName()));
+//        }
+//
+//        public UpdateEffect<FacilityV> onEvent(FacilityEvent.AddressChanged event) {
+//            return effects().updateState(viewState().withAddress(event.address().toAddressState()));
+//        }
+//
+//        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ResourceSubmitted event) {
+//            return effects().ignore();
+//        }
+//
+//        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ResourceIdAdded event) {
+//            return effects().updateState(viewState());
+//        }
+//
+//        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ResourceIdRemoved event) {
+//            return effects().updateState(viewState());
+//        }
+//
+//        public View.UpdateEffect<FacilityV> onEvent(FacilityEvent.ReservationCreated event) {
+//            return effects().ignore();
+//        }
+//    }
+//
+//    @Table("resources")
+//    @Subscribe.EventSourcedEntity(ResourceEntity.class)
+//    public static class Resources extends View<ResourceV> {
+//
+//        public UpdateEffect<ResourceV> onEvent(ResourceEvent.ResourceCreated created) {
+//            String id = updateContext().eventSubject().orElse("");
+//            assert id.equals(created.entityId());
+//            return effects().updateState(ResourceV.initialize(created));
+//        }
+//
+//        public UpdateEffect<ResourceV> onEvent(ResourceEvent.BookingAccepted event) {
+//            return effects().ignore();
+//        }
+//
+//        public UpdateEffect<ResourceV> onEvent(ResourceEvent.BookingRejected notInteresting) {
+//            return effects().ignore();
+//        }
+//    }
+//}

--- a/facility/src/main/java/com/rez/facility/view/ResourceV.java
+++ b/facility/src/main/java/com/rez/facility/view/ResourceV.java
@@ -1,7 +1,14 @@
 package com.rez.facility.view;
 
+import com.rez.facility.api.ResourceEvent;
+
 public record ResourceV(String facilityId, String resourceId, String resourceName, String[] timeWindow) {
-    public static ResourceV initialize(String facilityId, String resourceId, com.rez.facility.domain.Resource resource) {
+    public static ResourceV initialize(ResourceEvent.ResourceCreated created) {
+        String facilityId = created.facilityId();
+        String resourceId = created.entityId();
+        com.rez.facility.domain.Resource resource = created.resource() == null
+                ? com.rez.facility.domain.Resource.initialize("noname", 0)
+                : created.resource().toResourceState();
         return new ResourceV(facilityId, resourceId, resource.name(), resource.timeWindow());
     }
 

--- a/facility/src/main/java/com/rez/facility/view/ResourceView.java
+++ b/facility/src/main/java/com/rez/facility/view/ResourceView.java
@@ -24,8 +24,7 @@ public class ResourceView extends View<ResourceV> {
     public UpdateEffect<ResourceV> onEvent(ResourceEvent.ResourceCreated created) {
         String id = updateContext().eventSubject().orElse("");
         assert id.equals(created.entityId());
-        return effects().updateState(ResourceV.initialize(created.facilityId(),
-                created.entityId(), created.resource().toResourceState()));
+        return effects().updateState(ResourceV.initialize(created));
     }
 
     @Subscribe.EventSourcedEntity(ResourceEntity.class)

--- a/facility/src/main/resources/application.conf
+++ b/facility/src/main/resources/application.conf
@@ -1,4 +1,16 @@
 twist {
   url = "https://twist.com/api/v3/integration_incoming/post_data"
-  install_id = "411374"
+  install_id = "412390"
+}
+google {
+  //A facility calendar contains all src parameters, which are all its resources
+  //Example of a facility calendar (full url) with two resources (two calendars):
+  //https://calendar.google.com/calendar/u/0/embed?src=3d228lvsdmdjmj79662t8r1fh4@group.calendar.google.com&ctz=Europe/Berlin&src=63hd39cd9ppt8tajp76vglt394@group.calendar.google.com
+  scheme = "https"
+  host = "calendar.google.com";
+  path = "calendar/u/0/embed"
+  ctz = "Europe/Berlin"
+  // src params (calendar ids) should be formed by concatanating the resourceId with the srcTail.
+  // Example: 3d228lvsdmdjmj79662t8r1fh4@group.calendar.google.com
+  srcTail = "@group.calendar.google.com"
 }

--- a/facility/src/test/java/com/rez/facility/api/ConfigTest.java
+++ b/facility/src/test/java/com/rez/facility/api/ConfigTest.java
@@ -26,7 +26,7 @@ public class ConfigTest {
         String url = twistConfig.getString("url");
         Assertions.assertEquals("https://twist.com/api/v3/integration_incoming/post_data", url);
         String install_id = twistConfig.getString("install_id");
-        Assertions.assertEquals("411374", install_id);
+        Assertions.assertEquals("412390", install_id);
         String install_token = System.getenv("INSTALL_TOKEN");
         Assertions.assertEquals("t0k3n", install_token);
         String uri = url + "?install_id=" + install_id + "&install_token=" + install_token;

--- a/facility/src/test/java/com/rez/facility/api/DelegatingServiceActionTest.java
+++ b/facility/src/test/java/com/rez/facility/api/DelegatingServiceActionTest.java
@@ -1,0 +1,15 @@
+package com.rez.facility.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class DelegatingServiceActionTest {
+
+    @Test
+    void testListToString() {
+        List<String> attendees = List.of("Bob", "Tomas", "John");
+        String messageContent = String.join(",", attendees);
+        System.out.println("messageContent = " + messageContent);
+    }
+}

--- a/facility/src/test/java/com/rez/facility/parsers/StringParserTest.java
+++ b/facility/src/test/java/com/rez/facility/parsers/StringParserTest.java
@@ -1,0 +1,19 @@
+package com.rez.facility.parsers;
+
+import com.rez.facility.spi.Parser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StringParserTest {
+
+    @Test
+    void parse() {
+        String content = "2023-04-12, 14, Toni";
+        Parser parser = new StringParser();
+        Parser.Result rez = parser.parse(content);
+        assertEquals(rez.who().size(), 1);
+        assertEquals(rez.who().iterator().next(), "Toni");
+        assertEquals(rez.when(), "2023-04-12T14:00");
+    }
+}


### PR DESCRIPTION
Add simplistic parser implementation using string tokenization .
Disable joins, correct NPE, correct exception handling, one msg thread.

- DISABLED joins momentarily (support working on it)
- correct NPE over initial empty states causing problems in Views
- correct parsing exception handling
- webhook and doco in one thread instead of two separate ones (system_message, `WebhookAction.outwebhook`)
- correct message strings (minor)
- correct dependencies (`CalendarFactory`)

This commit resolved quite a number of issues encountered while both upgrading Kalix and re-creating the entire project from scratch (`kalix projects new ...`)