### PR TITLE
Reservation: renaming and FSM simplifications in ReservationEntity.

### DIFF
--- a/reservation/facility/src/it/java/com/rez/facility/WebClientUtil.java
+++ b/reservation/facility/src/it/java/com/rez/facility/WebClientUtil.java
@@ -117,7 +117,7 @@ public class WebClientUtil {
     var command = new ResourceEntity.CreateResourceCommand(facilityId, resourceDto);
 
     ResponseEntity<Void> response = webClient.post().uri("/resource/" + resourceId + "/create")
-      .body(Mono.just(command), ReservationEntity.InitiateReservation.class)
+      .body(Mono.just(command), ReservationEntity.Init.class)
       .retrieve()
       .toBodilessEntity()
       .block(timeout);

--- a/reservation/facility/src/main/java/com/rez/facility/actions/FacilityAction.java
+++ b/reservation/facility/src/main/java/com/rez/facility/actions/FacilityAction.java
@@ -36,7 +36,7 @@ public class FacilityAction extends Action {
     @SuppressWarnings("unused")
     public Effect<String> on(FacilityEvent.ReservationCreated event) {
         var reservationId = event.reservationId();
-        var command = new ReservationEntity.InitiateReservation(event.facilityId(), event.reservationDto(), event.resources());
+        var command = new ReservationEntity.Init(event.facilityId(), event.reservationDto(), event.resources());
         CompletionStage<Done> timerRegistration =
                 timers().startSingleTimer(
                         timerName(event.reservationId()),

--- a/reservation/facility/src/main/java/com/rez/facility/reservation/DelegatingServiceAction.java
+++ b/reservation/facility/src/main/java/com/rez/facility/reservation/DelegatingServiceAction.java
@@ -106,7 +106,7 @@ public class DelegatingServiceAction extends Action {
         return notificationSender.messageTwist(webClient, body);
     }
 
-    public Effect<String> on(ReservationEvent.Booked event) throws Exception {
+    public Effect<String> on(ReservationEvent.Fulfilled event) throws Exception {
         Reservation reservationDto = event.reservation();
         String reservationId = event.reservationId();
         List<String> resourceIds = event.resourceIds();

--- a/reservation/facility/src/main/java/com/rez/facility/reservation/ReservationEvent.java
+++ b/reservation/facility/src/main/java/com/rez/facility/reservation/ReservationEvent.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 public sealed interface ReservationEvent {
     @TypeName("reservation-initiated")
-    record ReservationInitiated(String reservationId, String facilityId, Reservation reservation,
-                                List<String> resources) implements ReservationEvent {}
+    record Inited(String reservationId, String facilityId, Reservation reservation,
+                  List<String> resources) implements ReservationEvent {}
     @TypeName("reservation-cancelled")
     record ReservationCancelled(String reservationId, String facilityId, Reservation reservation, String resourceId,
                                 List<String> resourceIds) implements ReservationEvent {}
@@ -19,17 +19,17 @@ public sealed interface ReservationEvent {
     @TypeName("search-exhausted")
     record SearchExhausted(String reservationId, String facilityId, Reservation reservation, List<String> resourceIds) implements ReservationEvent {}
 
-    @TypeName("waiting")
-    record Waiting(String reservationId, String resourceId) implements ReservationEvent {}
-    @TypeName("keep-waiting")
-    record KeepWaiting(String reservationId) implements ReservationEvent {}
+    @TypeName("rejectedWithNext")
+    record RejectedWithNext(String reservationId, String resourceId, String nextResourceId, String facilityId) implements ReservationEvent {}
+    @TypeName("rejected")
+    record Rejected(String reservationId, String resourceId) implements ReservationEvent {}
 
     @TypeName("resource-responded")
-    record ResourceResponded(String resourceId, String reservationId, Reservation reservation, boolean available, String facilityId) implements ReservationEvent {}
+    record AvailabilityReplied(String resourceId, String reservationId, Reservation reservation, boolean available, String facilityId) implements ReservationEvent {}
     @TypeName("candidate-flagged")
     record ResourceSelected(String resourceId, String reservationId, Reservation reservation, String facilityId) implements ReservationEvent {}
 
     @TypeName("booked")
-    record Booked(String resourceId, String reservationId, Reservation reservation, List<String> resourceIds,
-                  String facilityId) implements ReservationEvent {}
+    record Fulfilled(String resourceId, String reservationId, Reservation reservation, List<String> resourceIds,
+                     String facilityId) implements ReservationEvent {}
 }

--- a/reservation/facility/src/main/java/com/rez/facility/resource/ResourceEvent.java
+++ b/reservation/facility/src/main/java/com/rez/facility/resource/ResourceEvent.java
@@ -9,11 +9,11 @@ public sealed interface ResourceEvent {
 
     @TypeName("resource-created")
     record ResourceCreated(String resourceId, String resourceName, String facilityId) implements ResourceEvent {}
-    @TypeName("booking-accepted")
-    record BookingAccepted(String resourceId, String reservationId, String facilityId, Reservation reservationDto) implements ResourceEvent {}
-    @TypeName("booking-rejected")
-    record BookingRejected(String resourceId, String reservationId, String facilityId, Reservation reservation) implements ResourceEvent {}
-    record BookingCanceled(String resourceId, String reservationId, LocalDateTime dateTime) implements ResourceEvent {}
-    @TypeName("booking-available")
+    @TypeName("availability-checked")
     record AvalabilityChecked(String resourceId, String reservationId, boolean available, String facilityId) implements ResourceEvent {}
+    @TypeName("reservation-accepted")
+    record ReservationAccepted(String resourceId, String reservationId, String facilityId, Reservation reservationDto) implements ResourceEvent {}
+    @TypeName("reservation-rejected")
+    record ReservationRejected(String resourceId, String reservationId, String facilityId, Reservation reservation) implements ResourceEvent {}
+    record ReservationCanceled(String resourceId, String reservationId, LocalDateTime dateTime) implements ResourceEvent {}
 }

--- a/reservation/facility/src/main/java/com/rez/facility/resource/ResourceView.java
+++ b/reservation/facility/src/main/java/com/rez/facility/resource/ResourceView.java
@@ -12,12 +12,14 @@ import reactor.core.publisher.Flux;
 @Table("resources_by_facility_id")
 public class ResourceView extends View<ResourceV> {
 
+    @SuppressWarnings("unused")
     @GetMapping("/resource/by_facility/{facility_id}")
     @Query("SELECT * FROM resources_by_facility_id WHERE facilityId = :facility_id")
     public Flux<ResourceV> getResource(String facility_id) {
         return null;
     }
 
+    @SuppressWarnings("unused")
     @Subscribe.EventSourcedEntity(ResourceEntity.class)
     public UpdateEffect<ResourceV> onEvent(ResourceEvent.ResourceCreated created) {
         String id = updateContext().eventSubject().orElse("");
@@ -25,25 +27,29 @@ public class ResourceView extends View<ResourceV> {
         return effects().updateState(ResourceV.initialize(created));
     }
 
+    @SuppressWarnings("unused")
     @Subscribe.EventSourcedEntity(ResourceEntity.class)
-    public UpdateEffect<ResourceV> onEvent(ResourceEvent.BookingAccepted event) {
+    public UpdateEffect<ResourceV> onEvent(ResourceEvent.ReservationAccepted event) {
         String reservationId = event.reservationId();
         return effects().updateState(viewState().withBooking(event.reservationDto().dateTime(), reservationId));
     }
 
+    @SuppressWarnings("unused")
     @Subscribe.EventSourcedEntity(ResourceEntity.class)
-    public UpdateEffect<ResourceV> onEvent(ResourceEvent.BookingRejected notInteresting) {
+    public UpdateEffect<ResourceV> onEvent(ResourceEvent.ReservationRejected notInteresting) {
         return effects().ignore();
     }
 
 
+    @SuppressWarnings("unused")
     @Subscribe.EventSourcedEntity(ResourceEntity.class)
     public UpdateEffect<ResourceV> onEvent(ResourceEvent.AvalabilityChecked notInteresting) {
         return effects().ignore();
     }
 
+    @SuppressWarnings("unused")
     @Subscribe.EventSourcedEntity(ResourceEntity.class)
-    public UpdateEffect<ResourceV> onEvent(ResourceEvent.BookingCanceled cancellation) {
-        return effects().updateState(viewState().withoutBooking(cancellation.dateTime()));
+    public UpdateEffect<ResourceV> onEvent(ResourceEvent.ReservationCanceled event) {
+        return effects().updateState(viewState().withoutBooking(event.dateTime()));
     }
 }


### PR DESCRIPTION
Renames and simplifications:
- Booked -> Fulfilled
- InitiateReservation -> Init
- ReservationInitiated -> Inited
- BookIt -> Reserve
- Waiting -> RejectedWithNext
- Wait -> removed in favor of ReplyAvailability
- KeepWaiting -> Rejected
- ResourceResponded -> AvailabilityReplied
- tryNext endpoint -> removed, in favor of the similar replyAvailability
- BookingRejected -> ReservationRejected
- InquireBooking -> CheckAvailability
- BookingAccepted -> ReservationAccepted
- BookingRejected -> ReservationRejected
- BookingCanceled -> ReservationCanceled